### PR TITLE
Updated AWS SDK version and added attributes for manual install

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,3 @@
+default['aws-codedeploy-agent']['git-archive'] = 'https://github.com/aws/aws-codedeploy-agent/archive/master.zip'
 default['aws-codedeploy-agent']['ruby-version'] = '2.0.0-p645'
+default['aws-codedeploy-agent']['aws-sdk-version'] = '2.2.2'

--- a/definitions/manual_installer.rb
+++ b/definitions/manual_installer.rb
@@ -7,7 +7,7 @@ define :manual_installer do
   include_recipe 'awscli'
 
   ark 'download-codedeploy' do
-    url 'https://github.com/aws/aws-codedeploy-agent/archive/master.zip'
+    url node['aws-codedeploy-agent']['git-archive']
     path '/opt'
     action :put
   end
@@ -36,7 +36,7 @@ define :manual_installer do
 
   rbenv_gem 'aws-sdk-core' do
     ruby_version node['aws-codedeploy-agent']['ruby-version']
-    version '2.1.2'
+    version node['aws-codedeploy-agent']['aws-sdk-version']
   end
 
   link '/usr/bin/ruby2.0' do


### PR DESCRIPTION
Latest versions of codedeploy-agent use AWS SDK v2.2.2, need to bump it up.
