### PR TITLE
Current agent needs at least 2.3.x for its AWS SDK.

### DIFF
--- a/definitions/manual_installer.rb
+++ b/definitions/manual_installer.rb
@@ -36,7 +36,7 @@ define :manual_installer do
 
   rbenv_gem 'aws-sdk-core' do
     ruby_version node['aws-codedeploy-agent']['ruby-version']
-    version '2.1.2'
+    version '2.3.17'
   end
 
   link '/usr/bin/ruby2.0' do


### PR DESCRIPTION
The current recipe fails out-of-box since the master branch of the agent requires at least 2.3.x.
