### PR TITLE
Leave service provider for Chef to figure out.

### DIFF
--- a/definitions/manual_installer.rb
+++ b/definitions/manual_installer.rb
@@ -59,7 +59,6 @@ define :manual_installer do
   end
 
   service 'codedeploy-agent' do
-    provider Chef::Provider::Service::Init
     action [:enable, :start]
   end
 end


### PR DESCRIPTION
The ::Init provider doesn't support :enable, but if you leave it up to
Chef to detect automatically, it'll work because the platform-specific
sub-classes do support :enable.
