### PR TITLE
filtering the grep process from the process checking test

### DIFF
--- a/test/integration/aws-codedeploy-agent/serverspec/default_spec.rb
+++ b/test/integration/aws-codedeploy-agent/serverspec/default_spec.rb
@@ -6,6 +6,6 @@ describe service('codedeploy-agent') do
   it { should be_enabled }
 end
 
-describe command('ps -ax | grep "codedeploy-agent: InstanceAgent"') do
+describe command('ps -ax | grep "codedeploy-agent: InstanceAgent" | grep -v grep') do
   its(:stdout) { should match /codedeploy-agent: InstanceAgent/ }
 end


### PR DESCRIPTION
In response to https://github.com/continuousphp/aws-codedeploy-agent/issues/10

**NB** This results in the test failing, however, it appears that the test should fail.
