### PR TITLE
Issue 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The following platforms are supported by this cookbook.
 
 Attributes
 ----------
-Customize the attributes to set ruby version requirements of AWS aws-codedeploy-agent (currently 2.0.0-p645) 
+Customize the version of aws-codedeploy-agent to be installed and the version of the ruby and aws-sdk-core dependencies
 
 #### aws-codedeploy-agent::default
 
@@ -35,6 +35,18 @@ Customize the attributes to set ruby version requirements of AWS aws-codedeploy-
     <td>string</td>
     <td>Set the default ruby version of code deploy</td>
     <td><tt>2.1.5</tt></td>
+  </tr>
+  <tr>
+    <td><tt>node['aws-codedeploy-agent']['aws_sdk_core-version']</tt></td>
+    <td>string</td>
+    <td>Set the version of aws-sdk-core gem. See <a href="https://rubygems.org/gems/aws-sdk-core/versions/2.3.17">rubygems for alternate release versions.</a></td>
+    <td><tt>2.6.11</tt></td>
+  </tr>
+  <tr>
+    <td><tt>node['aws-codedeploy-agent']['aws_codedeploy_agent-version']</tt></td>
+    <td>string</td>
+    <td>Set the version of the code deploy agent to be installed. Tracks master, other options include &quot;v1.0-1011&quot; or see <a href="https://github.com/aws/aws-codedeploy-agent/releases">the release archive for available, tagged versions</a> </td>
+    <td><tt>master</tt></td>
   </tr>
 </table>
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,3 @@
 default['aws-codedeploy-agent']['rbenv_ruby-version'] = '2.1.5'
 default['aws-codedeploy-agent']['aws_sdk_core-version'] = '2.6.11'
-default['aws-codedeploy-agent']['aws_codedeploy_agent-version'] = 'master'
+default['aws-codedeploy-agent']['aws_codedeploy_agent-version'] = 'v1.0-1045'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,3 @@
 default['aws-codedeploy-agent']['rbenv_ruby-version'] = '2.1.5'
 default['aws-codedeploy-agent']['aws_sdk_core-version'] = '2.6.11'
+node['aws-codedeploy-agent']['aws_codedeploy_agent-version'] = 'master'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,2 @@
 default['aws-codedeploy-agent']['rbenv_ruby-version'] = '2.1.5'
+default['aws-codedeploy-agent']['aws_sdk_core-version'] = '2.6.11'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,3 @@
 default['aws-codedeploy-agent']['rbenv_ruby-version'] = '2.1.5'
 default['aws-codedeploy-agent']['aws_sdk_core-version'] = '2.6.11'
-node['aws-codedeploy-agent']['aws_codedeploy_agent-version'] = 'master'
+default['aws-codedeploy-agent']['aws_codedeploy_agent-version'] = 'master'

--- a/definitions/download_installer.rb
+++ b/definitions/download_installer.rb
@@ -42,7 +42,7 @@ define :download_installer do
 
   rbenv_gem 'aws-sdk-core' do
     rbenv_version node['aws-codedeploy-agent']['rbenv_ruby-version']
-    version '2.3.17'
+    version node['aws-codedeploy-agent']['aws_sdk_core-version']
   end
 
   link '/usr/bin/ruby2.0' do

--- a/definitions/download_installer.rb
+++ b/definitions/download_installer.rb
@@ -7,7 +7,7 @@ define :download_installer do
   include_recipe 'cloudcli'
 
   ark 'download-codedeploy' do
-    url 'https://github.com/aws/aws-codedeploy-agent/archive/master.zip'
+    url "https://github.com/aws/aws-codedeploy-agent/archive/#{node['aws-codedeploy-agent']['aws_codedeploy_agent-version']}.zip"
     path '/opt'
     action :put
   end

--- a/definitions/manual_installer.rb
+++ b/definitions/manual_installer.rb
@@ -37,7 +37,7 @@ define :manual_installer do
 
   rbenv_gem 'aws-sdk-core' do
     rbenv_version node['aws-codedeploy-agent']['rbenv_ruby-version']
-    version '2.3.17'
+    version node['aws-codedeploy-agent']['aws_sdk_core-version']
   end
 
   link '/usr/bin/ruby2.0' do

--- a/definitions/manual_installer.rb
+++ b/definitions/manual_installer.rb
@@ -7,7 +7,7 @@ define :manual_installer do
   include_recipe 'cloudcli'
 
   ark 'download-codedeploy' do
-    url 'https://github.com/aws/aws-codedeploy-agent/archive/master.zip'
+    url "https://github.com/aws/aws-codedeploy-agent/archive/#{node['aws-codedeploy-agent']['aws_codedeploy_agent-version']}.zip"
     path '/opt'
     action :put
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'oswald@continuousphp.com'
 license          'Apache 2.0'
 description      'Installs/Configures aws-codedeploy-agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.6.0'
+version          '0.6.1'
 
 supports 'ubuntu'
 supports 'centos'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'oswald@continuousphp.com'
 license          'Apache 2.0'
 description      'Installs/Configures aws-codedeploy-agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.6.1'
+version          '0.7.0'
 
 supports 'ubuntu'
 supports 'centos'


### PR DESCRIPTION
Allows for versions of aws-core-sdk and aws-codeedploy-agent to be selected by attributes to solve dependency conflicts when installing aws-core-sdk v2.3.17 and current master build of aws-codedeploy-agent
